### PR TITLE
ffh-district-migrate: drop lua-minify

### DIFF
--- a/ffh-district-migrate/Makefile
+++ b/ffh-district-migrate/Makefile
@@ -6,9 +6,7 @@ PKG_RELEASE:=1
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
-# this includes lua minifying routine (GluonSrcDiet)
-# and also imports the normal $(INCLUDE_DIR)/package.mk
-include $(GLUONDIR)/include/package.mk
+include $(INCLUDE_DIR)/package.mk
 
 define Package/ffh-district-migrate
   SECTION:=gluon


### PR DESCRIPTION
> drop the minifying aspect for now

The package hasn't been used in years, but produces a build warning each time we use our package repo, which for us is each build.

> Makefile:11: /include/package.mk: No such file or directory
> make[3]: *** No rule to make target '/include/package.mk'.  Stop.

untested, but I expect this to get rid of the warning above