### PR TITLE
ffh-ntpd-gluon-state-check: Add package

### DIFF
--- a/ffh-ntpd-gluon-state-check/Makefile
+++ b/ffh-ntpd-gluon-state-check/Makefile
@@ -1,0 +1,13 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffh-ntpd-gluon-state-check
+PKG_VERSION:=2
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffh-ntpd-gluon-state-check
+  TITLE:=Hotplug for gluon-state-check into ntpd
+  DEPENDS:=+gluon-core +gluon-state-check
+endef
+
+$(eval $(call BuildPackageGluon,ffh-ntpd-gluon-state-check))

--- a/ffh-ntpd-gluon-state-check/check_site.lua
+++ b/ffh-ntpd-gluon-state-check/check_site.lua
@@ -1,0 +1,1 @@
+need_string_array({'ntp_servers'}, true)

--- a/ffh-ntpd-gluon-state-check/files/etc/hotplug.d/ntp/21-gluon-state-check
+++ b/ffh-ntpd-gluon-state-check/files/etc/hotplug.d/ntp/21-gluon-state-check
@@ -1,0 +1,5 @@
+#!/bin/sh
+sync_flag="/var/gluon/state/has_ntp_sync"
+unsync_flag="/var/gluon/state/has_lost_ntp_sync"
+[ $stratum = 16 ] && touch -a $unsync_flag && rm -f $sync_flag
+[ $stratum -lt 16 ] && touch -a $sync_flag && rm -f $unsync_flag

--- a/ffh-ntpd-gluon-state-check/files/usr/bin/ffh_ntp_info
+++ b/ffh-ntpd-gluon-state-check/files/usr/bin/ffh_ntp_info
@@ -1,0 +1,52 @@
+#!/bin/busybox sh
+
+# Show the current ntp state using gluon-state-check.
+#
+# In case of an unsynced ntp session the file has_lost_ntp_sync is created.
+# Its atime will be bumped upon further failed synchronizations.
+# As long as there is no sync, the file has_ntp_sync is absent.
+#
+# Vice versa, the file has_ntp_sync is created upon stratum-level <16.
+# As long as the sync persists, only the files atime is updated.
+# Furthermore, if there is an ntp sync, the file has_lost_ntp_sync is deleted.
+#
+# This allows the following code to emit the current ntp status and how long its been going on.
+
+# These two variables must not contain spaces in order for the awk splitting to work.
+HAS_LOST_NTP_SYNC="/var/gluon/state/has_lost_ntp_sync"
+HAS_NTP_SYNC="/var/gluon/state/has_ntp_sync"
+
+get_duration() {
+    local flag_file
+    local use_atime
+    local mtime
+    local time_epoch
+    local current_time
+
+    flag_file=$1
+    use_atime=$2
+
+    if [ "$use_atime" = true ]; then
+        ls_option="-u"
+    fi
+
+    # shellcheck disable=SC2012 # stat is unavailable and busybox find does not emit the necessary fields.
+    mtime=$(ls -l "$ls_option" "$flag_file" --full-time | awk '{print $6, $7}') 2>/dev/null
+    time_epoch=$(date -d "$mtime" +%s)
+    current_time=$(date +%s)
+    echo $((current_time - time_epoch))
+}
+
+if [ -f "$HAS_NTP_SYNC" ]; then
+    duration=$(get_duration "$HAS_NTP_SYNC")
+    last_checked=$(get_duration "$HAS_NTP_SYNC" true)
+    echo "NTP has been synced for $duration seconds (last checked $last_checked seconds ago)."
+elif [ -f "$HAS_LOST_NTP_SYNC" ]; then
+    duration=$(get_duration "$HAS_LOST_NTP_SYNC")
+    last_checked=$(get_duration "$HAS_LOST_NTP_SYNC" true)
+    echo "NTP has been unsynced for $duration seconds (last checked $last_checked seconds ago)."
+else
+    echo "NTP state is unknown, ntpd hotplugs might not have been invoked, yet."
+fi
+
+


### PR DESCRIPTION
> a hotplug for busybox ntpd, which provides the current ntp sync state as a gluon-state-check.